### PR TITLE
Initial checkin of xcatha-failover

### DIFF
--- a/HA/xcatha-failover.py
+++ b/HA/xcatha-failover.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+###############################################################################
+# IBM(c) 2018 EPL license http://www.eclipse.org/legal/epl-v10.html
+###############################################################################
+# -*- coding: utf-8 -*-
+#  CHANGE HISTORY:
+#   
+#  NAME:  xcatha-failover.py
+#
+#  SYNTAX: xcatha-failover.py -a|--activate -p <shared-data directory path> -i <nic> -v <virtual ip> [-m <netmask>] [-t <database type>] 
+#  SYNTAX: xcatha-failover.py -d|--deactivate -i <nic> -v <virtual ip>
+#
+#  DESCRIPTION:  Activate/Deactivate this node to be the shared data based xCAT MN
+#
+#  FLAGS:
+#               -p      the shared data directory path
+#               -i      the nic that the virtual ip address attaches to,
+#                       for Linux, it could be eth0:1 or eth1:2 or ...
+#               -v      virtual ip address
+#               -m      netmask for the virtual ip address,
+#                       default to 255.255.255.0
+#               -n      virtual ip hostname, default ?
+#               -t      target database type, it can be postgresql, default is sqlite
+import argparse
+from xcatha_setup import xcat_ha_utils, HaException
+
+def parse_arguments():
+    """parse input arguments"""
+    parser = argparse.ArgumentParser(description="Activate/Deactivate shared data based xCAT HA MN node")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-a', '--activate', help="activate node to be xCAT MN", action='store_true')
+    group.add_argument('-d', '--deactivate', help="deactivate node to be xCAT MN", action='store_true')
+
+    parser.add_argument('-v', dest="virtual_ip", required=True, help="virtual IP")
+    parser.add_argument('-i', dest="nic", required=True, help="virtual IP network interface")
+
+    parser.add_argument('-p', dest="path", help="shared data directory path")
+    parser.add_argument('-n', dest="host_name", help="virtual IP hostname")
+    parser.add_argument('-m', dest="netmask", help="virtual IP network mask")
+    parser.add_argument('-t', dest="dbtype", choices=['postgresql', 'sqlite'], help="database type")
+    args = parser.parse_args()
+    return args
+
+def main():
+    args=parse_arguments()
+    obj=xcat_ha_utils()
+    try:
+        if args.activate:
+            if args.path:
+                print "Option -p is not valid for xCAT MN deactivation"
+            if not args.netmask:
+                args.netmask="255.255.255.0"
+            if not args.dbtype:
+                args.dbtype="sqlite"
+            if not args.host_name:
+                print "Argument -n is required"
+                return
+
+            print "Activating this node as xCAT MN"
+            obj.activate_management_node(args.nic, args.virtual_ip, args.dbtype, args.path, args.host_name, args.netmask)
+        if args.deactivate:
+            if args.dbtype:
+                print "Option -t is not valid for xCAT MN deactivation"
+                return
+            if args.netmask:
+                print "Option -m is not valid for xCAT MN deactivation"
+                return
+            if args.host_name:
+                print "Option -n is not valid for xCAT MN deactivation"
+                return
+
+            print "Deactivating this node as xCAT MN"
+            dbtype=obj.current_database_type("")
+            obj.deactivate_management_node(args.nic, args.virtual_ip, dbtype)
+
+    except HaException,e:
+        error_msg="=================="+e.message+"=================================="
+        print error_msg        
+        print "Error encountered, starting to clean up the environment"
+        obj.clean_env(args.virtual_ip, args.nic, args.host_name)
+
+if __name__ == "__main__":
+    main()

--- a/HA/xcatha-setup.py
+++ b/HA/xcatha-setup.py
@@ -18,6 +18,7 @@
 #               -v      virtual ip address
 #               -m      netmask for the virtual ip address,
 #                       default to 255.255.255.0
+#               -n      virtual ip hostname, default ?
 #               -t      target database type, it can be postgresql, default is sqlite
 import argparse
 import os
@@ -402,8 +403,23 @@ class xcat_ha_utils:
                 os.symlink(xcat_file_path, sharedfs[i])     
             i += 1
 
+    def unconfigure_shared_data(self, sharedfs):
+        """unconfigure shared data directory"""
+        global setup_process_msg
+        setup_process_msg="Unconfigure shared data directory stage"
+        self.log_info(setup_process_msg)
+        #1.check if there is xcat data in shared data directory
+        #2.unlink data in shared data directory
+        i=0
+        while i < len(sharedfs):
+            print "remove symlink ..."+sharedfs[i]
+            if os.path.islink(sharedfs[i]):
+                os.unlink(xcat_file_path, sharedfs[i])     
+            i += 1
+
     def clean_env(self, vip, nic, host):
         """clean up env when exception happen"""
+        self.unconfigure_shared_data(shared_fs)
         self.unconfigure_vip(vip, nic)
 
     def deactivate_management_node(self, nic, vip, dbtype):
@@ -422,10 +438,31 @@ class xcat_ha_utils:
         stop_db="service "+dbtype+" stop"
         self.execute_command(stop_db)
         self.execute_command("service ntpd restart")
+        self.unconfigure_shared_data(shared_fs)
         self.unconfigure_vip(vip, nic)
  
+    def activate_management_node(self, nic, vip, dbtype, path, hostname, mask):
+        """activate management node"""
+        global setup_process_msg
+        setup_process_msg="Activate stage"
+        self.log_info(setup_process_msg)
+        self.execute_command("chkconfig --level 345 xcatd off")
+        self.execute_command("chkconfig --level 2345 conserver off")
+        self.execute_command("chkconfig --level 2345 dhcpd off")
+        self.execute_command("chkconfig postgresql off")
+        self.execute_command("service conserver start")
+        self.execute_command("service dhcpd start")
+        self.execute_command("service named start")
+        self.execute_command("service xcatd start")
+        start_db="service "+dbtype+" start"
+        self.execute_command(start_db)
+        self.execute_command("service ntpd restart")
+        self.change_hostname(host_name,args.vip)
+        self.configure_shared_data(args.path, shared_fs)
+        self.configure_vip(vip, nic)
+ 
     def xcatha_setup_mn(self, args):
-        """main process"""
+        """setup_mn process"""
         try:
             self.vip_check(args.virtual_ip)
             if self.check_xcat_exist_in_shared_data(args.path):
@@ -447,27 +484,27 @@ class xcat_ha_utils:
         except:
             raise HaException("Error: "+setup_process_msg+" [Failed]")
 
-def parser_arguments():
-    """parser input arguments"""
+def parse_arguments():
+    """parse input arguments"""
     parser = argparse.ArgumentParser(description="setup and configure shared data based xCAT HA MN node")
     parser.add_argument('-p', dest="path", required=True, help="shared data directory path")
     parser.add_argument('-v', dest="virtual_ip", required=True, help="virtual IP")
     parser.add_argument('-i', dest="nic", required=True, help="virtual IP network interface")
     parser.add_argument('-n', dest="host_name", required=True, help="virtual IP hostname")
     parser.add_argument('-m', dest="netmask", default="255.255.255.0", help="virtual IP network mask")
-    parser.add_argument('-t', dest="dbtype", default="sqlite", help="database type")
+    parser.add_argument('-t', dest="dbtype", default="sqlite", choices=['postgresql', 'sqlite'], help="database type")
     args = parser.parse_args()
     return args
 
 def main():
-    args=parser_arguments()
+    args=parse_arguments()
     obj=xcat_ha_utils()
     try:
         obj.xcatha_setup_mn(args)
     except HaException,e:
         error_msg="=================="+e.message+"=================================="
         print error_msg        
-        print "Error happen, start to clean up environment"
+        print "Error encountered, starting to clean up the environment"
         obj.clean_env(args.virtual_ip, args.nic, args.host_name)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Initial work on xcatha-failover function.

Note: Import of `from xcatha_setup import xcat_ha_utils, HaException` fails with `xcatha-setup`, It seems the filename can not contain `-`, but `_` works.