### PR TITLE
enhance ha_mn and some dryrun information

### DIFF
--- a/HA/xcatha.py
+++ b/HA/xcatha.py
@@ -633,7 +633,7 @@ class xcat_ha_utils:
         setup_process_msg="Checking if "+package+" is installed ..."
         logger.info(setup_process_msg)
         res=0
-        cmd="rpm -qa|grep "+package+" > /dev/null"
+        cmd="rpm -q "+package+" > /dev/null"
         res=os.system(cmd)
         if dryrun:
             # In dryrun mode always return success.


### PR DESCRIPTION
for https://github.com/xcat2/xcat2-task-management/issues/161 and https://github.com/xcat2/xcat2-task-management/issues/172 and https://github.com/xcat2/xcat-extensions/issues/17

enhance:
1, fix duplicate lines in /etc/xcat/ha_mn
2, fix shared data path error message
3, add some dryrun for "Save physical hostname and ip"
4, fix package installed

UT:
```
[root@bybc0605 ~]# python xcatha.py -s -p /HAtest -v 10.5.106.22 -i eth0:0 -n bymn -m 255.0.0.0 -t mariadb --dryrun
2018-06-11 00:22:01,768 - INFO - Setup this node as xCAT HA standby MN
============================================================================================
2018-06-11 00:22:01,768 - INFO - Check virtual ip stage
2018-06-11 00:22:01,768 - INFO - ping -c 1 -w 10 10.5.106.22 [Dryrun]
2018-06-11 00:22:01,768 - INFO - Check if xCAT data is in shared data directory
2018-06-11 00:22:01,769 - INFO - There is xCAT data /HAtest/install in shared data /HAtest
============================================================================================
2018-06-11 00:22:01,769 - INFO - Check if target dbtype is the same with shared data dbtype stage
2018-06-11 00:22:01,769 - INFO - Database type is 'mariadb' in shared data directory
2018-06-11 00:22:01,769 - INFO - Target database type is matched [Dryrun]
============================================================================================
2018-06-11 00:22:01,769 - INFO - Configure virtual ip as alias ip stage
2018-06-11 00:22:01,770 - INFO - ifconfig eth0:0 10.5.106.22  netmask 255.0.0.0 [Dryrun]
2018-06-11 00:22:01,770 - INFO - Save physical hostname and ip
============================================================================================
2018-06-11 00:22:01,770 - INFO - Configure hostname stage
2018-06-11 00:22:01,770 - INFO - hostname bymn [Dryrun]
2018-06-11 00:22:01,770 - INFO - Check xcatd service status
============================================================================================
2018-06-11 00:22:01,770 - INFO - Check database type stage
2018-06-11 00:22:01,771 - INFO - Current xCAT database type: mariadb
2018-06-11 00:22:01,771 - INFO - Target xCAT database type: mariadb
2018-06-11 00:22:01,771 - INFO - No need to switch database
============================================================================================
2018-06-11 00:22:01,771 - INFO - Configure shared data directory stage
2018-06-11 00:22:01,771 - INFO - systemctl stop mariadb [Dryrun]
2018-06-11 00:22:01,781 - INFO - systemctl stop goconserver [Dryrun]
2018-06-11 00:22:01,782 - INFO - systemctl stop conserver [Dryrun]
2018-06-11 00:22:01,782 - INFO - systemctl stop ntpd [Dryrun]
2018-06-11 00:22:01,782 - INFO - systemctl stop dhcpd [Dryrun]
2018-06-11 00:22:01,782 - INFO - systemctl stop named [Dryrun]
2018-06-11 00:22:01,782 - INFO - systemctl stop xcatd [Dryrun]
2018-06-11 00:22:01,782 - INFO - systemctl stop mariadb [Dryrun]
2018-06-11 00:22:01,782 - INFO - Creating symlink .../install [Dryrun]
2018-06-11 00:22:01,782 - INFO - Creating symlink .../etc/xcat [Dryrun]
2018-06-11 00:22:01,782 - INFO - Creating symlink .../root/.xcat [Dryrun]
2018-06-11 00:22:01,782 - INFO - Creating symlink .../var/lib/mysql [Dryrun]
2018-06-11 00:22:01,782 - INFO - Creating symlink .../tftpboot [Dryrun]
2018-06-11 00:22:01,783 - INFO - touch /etc/xcat/ha_mn [Dryrun]
2018-06-11 00:22:01,798 - INFO - orignal ip and hostname:10.5.106.5 bybc0605.cluster.com [Dryrun]
2018-06-11 00:22:01,798 - INFO - systemctl restart mariadb [Dryrun]
2018-06-11 00:22:01,798 - INFO - Check xcatd service status
2018-06-11 00:22:01,798 - INFO - xCAT service has started [Dryrun]
============================================================================================
2018-06-11 00:22:01,798 - INFO - Configure xCAT policy table stage
2018-06-11 00:22:01,798 - INFO - lsdef -t policy -i name|grep bymn [Dryrun]
############################################################################################
2018-06-11 00:22:01,799 - INFO - Deactivate stage
============================================================================================
2018-06-11 00:22:01,813 - INFO - Configure hostname stage
2018-06-11 00:22:01,814 - INFO - hostname bybc0605.cluster.com [Dryrun]
============================================================================================
2018-06-11 00:22:01,814 - INFO - Unconfigure shared data directory stage
2018-06-11 00:22:01,814 - INFO - Removing symlink .../install [Dryrun]
2018-06-11 00:22:01,814 - INFO - Removing symlink .../etc/xcat [Dryrun]
2018-06-11 00:22:01,814 - INFO - Removing symlink .../root/.xcat [Dryrun]
2018-06-11 00:22:01,814 - INFO - Removing symlink .../var/lib/mysql [Dryrun]
2018-06-11 00:22:01,814 - INFO - Removing symlink .../tftpboot [Dryrun]
============================================================================================
2018-06-11 00:22:01,814 - INFO - Remove virtual IP stage
2018-06-11 00:22:01,814 - INFO - ifconfig eth0:0 0.0.0.0 0.0.0.0 &>/dev/null [Dryrun]
2018-06-11 00:22:01,814 - INFO - ip addr show |grep 10.5.106.22 &>/dev/null [Dryrun]
2018-06-11 00:22:01,815 - INFO - systemctl disable goconserver [Dryrun]
2018-06-11 00:22:01,815 - INFO - systemctl disable conserver [Dryrun]
2018-06-11 00:22:01,815 - INFO - systemctl disable ntpd [Dryrun]
2018-06-11 00:22:01,815 - INFO - systemctl disable dhcpd [Dryrun]
2018-06-11 00:22:01,815 - INFO - systemctl disable named [Dryrun]
2018-06-11 00:22:01,815 - INFO - systemctl disable xcatd [Dryrun]
2018-06-11 00:22:01,815 - INFO - systemctl disable mariadb [Dryrun]
2018-06-11 00:22:01,823 - INFO - systemctl stop goconserver [Dryrun]
2018-06-11 00:22:01,824 - INFO - systemctl stop conserver [Dryrun]
2018-06-11 00:22:01,824 - INFO - systemctl stop ntpd [Dryrun]
2018-06-11 00:22:01,824 - INFO - systemctl stop dhcpd [Dryrun]
2018-06-11 00:22:01,824 - INFO - systemctl stop named [Dryrun]
2018-06-11 00:22:01,824 - INFO - systemctl stop xcatd [Dryrun]
2018-06-11 00:22:01,824 - INFO - systemctl stop mariadb [Dryrun]
2018-06-11 00:22:01,824 - INFO - This machine is set to standby management node successfully...
[root@bybc0605 ~]#
[root@bybc0605 ~]#
[root@bybc0605 ~]#
[root@bybc0605 ~]#
[root@bybc0605 ~]# python xcatha.py -s -p /HAtest -v 10.5.106.22 -i eth0:0 -n bymn -m 255.0.0.0 -t mariadb
2018-06-11 00:22:13,640 - INFO - Setup this node as xCAT HA standby MN
============================================================================================
2018-06-11 00:22:13,641 - INFO - Check virtual ip stage
2018-06-11 00:22:13,641 - INFO - ping -c 1 -w 10 10.5.106.22
PING 10.5.106.22 (10.5.106.22) 56(84) bytes of data.
From 10.5.106.5 icmp_seq=1 Destination Host Unreachable
From 10.5.106.5 icmp_seq=2 Destination Host Unreachable

--- 10.5.106.22 ping statistics ---
2 packets transmitted, 0 received, +2 errors, 100% packet loss, time 999ms
pipe 2
2018-06-11 00:22:14,700 - INFO - virtual ip can be used.
2018-06-11 00:22:14,700 - INFO - Check if xCAT data is in shared data directory
2018-06-11 00:22:14,701 - INFO - There is xCAT data /HAtest/install in shared data /HAtest
============================================================================================
2018-06-11 00:22:14,701 - INFO - Check if target dbtype is the same with shared data dbtype stage
2018-06-11 00:22:14,701 - INFO - Database type is 'mariadb' in shared data directory
2018-06-11 00:22:14,701 - INFO - Target database type is matched [Passed]
============================================================================================
2018-06-11 00:22:14,701 - INFO - Configure virtual ip as alias ip stage
2018-06-11 00:22:14,704 - INFO - ifconfig eth0:0 10.5.106.22  netmask 255.0.0.0 [Passed]
2018-06-11 00:22:14,704 - INFO - Save physical hostname and ip
============================================================================================
2018-06-11 00:22:14,705 - INFO - Configure hostname stage
2018-06-11 00:22:14,707 - INFO - hostname bymn [Passed]
2018-06-11 00:22:14,707 - INFO - Check xcatd service status
============================================================================================
2018-06-11 00:22:14,713 - INFO - Install xCAT stage
2018-06-11 00:22:14,713 - INFO - Checking if xCAT is installed ...
2018-06-11 00:22:14,724 - INFO - xCAT already installed
============================================================================================
2018-06-11 00:22:14,725 - INFO - Check database type stage
2018-06-11 00:22:14,725 - INFO - Current xCAT database type: mariadb
2018-06-11 00:22:14,725 - INFO - Target xCAT database type: mariadb
2018-06-11 00:22:14,725 - INFO - No need to switch database
============================================================================================
2018-06-11 00:22:14,725 - INFO - Configure shared data directory stage
2018-06-11 00:22:14,736 - INFO - systemctl stop mariadb [Passed]
2018-06-11 00:22:14,756 - INFO - systemctl stop goconserver [Passed]
2018-06-11 00:22:14,767 - INFO - systemctl stop conserver [Passed]
2018-06-11 00:22:14,777 - INFO - systemctl stop ntpd [Passed]
2018-06-11 00:22:14,787 - INFO - systemctl stop dhcpd [Passed]
2018-06-11 00:22:14,799 - INFO - systemctl stop named [Passed]
2018-06-11 00:22:14,809 - INFO - systemctl stop xcatd [Passed]
2018-06-11 00:22:14,819 - INFO - systemctl stop mariadb [Passed]
2018-06-11 00:22:14,820 - INFO - Creating symlink .../install
2018-06-11 00:22:14,820 - INFO - Creating symlink .../etc/xcat
2018-06-11 00:22:14,820 - INFO - Creating symlink .../root/.xcat
2018-06-11 00:22:14,820 - INFO - Creating symlink .../var/lib/mysql
2018-06-11 00:22:14,820 - INFO - Creating symlink .../tftpboot
2018-06-11 00:22:16,923 - INFO - systemctl restart mariadb [Passed]
2018-06-11 00:22:16,923 - INFO - Check xcatd service status
2018-06-11 00:22:19,131 - INFO - systemctl restart xcatd [Passed]
2018-06-11 00:22:19,132 - INFO - xCAT service has started [Passed]
============================================================================================
2018-06-11 00:22:19,132 - INFO - Configure xCAT policy table stage
2018-06-11 00:22:19,134 - INFO - lsdef -t policy -i name|grep bymn
    name=bymn
2018-06-11 00:22:19,466 - INFO - bymn exists in policy table.
############################################################################################
2018-06-11 00:22:19,466 - INFO - Deactivate stage
============================================================================================
2018-06-11 00:22:19,488 - INFO - Configure hostname stage
2018-06-11 00:22:19,490 - INFO - hostname bybc0605.cluster.com [Passed]
============================================================================================
2018-06-11 00:22:19,490 - INFO - Unconfigure shared data directory stage
2018-06-11 00:22:19,490 - INFO - Removing symlink .../install
2018-06-11 00:22:19,491 - INFO - Restoring local directory .../install
2018-06-11 00:22:19,491 - INFO - Removing symlink .../etc/xcat
2018-06-11 00:22:19,491 - INFO - Restoring local directory .../etc/xcat
2018-06-11 00:22:19,491 - INFO - Removing symlink .../root/.xcat
2018-06-11 00:22:19,491 - INFO - Restoring local directory .../root/.xcat
2018-06-11 00:22:19,491 - INFO - Removing symlink .../var/lib/mysql
2018-06-11 00:22:19,491 - INFO - Restoring local directory .../var/lib/mysql
2018-06-11 00:22:19,492 - INFO - Removing symlink .../tftpboot
2018-06-11 00:22:19,492 - INFO - Restoring local directory .../tftpboot
============================================================================================
2018-06-11 00:22:19,492 - INFO - Remove virtual IP stage
2018-06-11 00:22:19,494 - INFO - ifconfig eth0:0 0.0.0.0 0.0.0.0 &>/dev/null [Failed, OK to ignore]
2018-06-11 00:22:19,497 - INFO - ip addr show |grep 10.5.106.22 &>/dev/null [Failed, OK to ignore]
2018-06-11 00:22:19,498 - INFO - Remove virtual IP [Passed]
2018-06-11 00:22:19,562 - INFO - systemctl disable goconserver [Passed]
conserver.service is not a native service, redirecting to /sbin/chkconfig.
Executing /sbin/chkconfig conserver off
2018-06-11 00:22:19,615 - INFO - systemctl disable conserver [Passed]
2018-06-11 00:22:19,660 - INFO - systemctl disable ntpd [Passed]
2018-06-11 00:22:19,703 - INFO - systemctl disable dhcpd [Passed]
2018-06-11 00:22:19,748 - INFO - systemctl disable named [Passed]
xcatd.service is not a native service, redirecting to /sbin/chkconfig.
Executing /sbin/chkconfig xcatd off
2018-06-11 00:22:19,798 - INFO - systemctl disable xcatd [Passed]
2018-06-11 00:22:19,844 - INFO - systemctl disable mariadb [Passed]
2018-06-11 00:22:19,866 - INFO - systemctl stop goconserver [Passed]
2018-06-11 00:22:19,877 - INFO - systemctl stop conserver [Passed]
2018-06-11 00:22:19,887 - INFO - systemctl stop ntpd [Passed]
2018-06-11 00:22:19,897 - INFO - systemctl stop dhcpd [Passed]
2018-06-11 00:22:19,908 - INFO - systemctl stop named [Passed]
2018-06-11 00:22:23,291 - INFO - systemctl stop xcatd [Passed]
2018-06-11 00:22:25,417 - INFO - systemctl stop mariadb [Passed]
2018-06-11 00:22:25,418 - INFO - This machine is set to standby management node successfully...
[root@bybc0605 ~]#
```