### PR TITLE
Support interactive deactivate

### DIFF
--- a/HA/xcatha.py
+++ b/HA/xcatha.py
@@ -1094,7 +1094,6 @@ def main():
                 elif return_code is 0:
                     dryrun=0
                 obj.disable_all_services(service_list, dbtype)
-                logger.info("This machine is set to standby management node successfully...") 
         if args.setup:
             if not args.netmask:
                 args.netmask="255.255.255.0"

--- a/HA/xcatha.py
+++ b/HA/xcatha.py
@@ -163,9 +163,11 @@ class xcat_ha_utils:
             servicelist.remove('postgresql')
         elif dbtype == 'postgresql' and 'mariadb' in servicelist:
             servicelist.remove('mariadb')
-        elif dbtype == 'sqlite' and 'postgresql' in servicelist and 'mariadb' in servicelist:
-            servicelist.remove('postgresql')
-            servicelist.remove('mariadb')
+        elif dbtype == 'sqlite':
+            if 'postgresql' in servicelist:
+                servicelist.remove('postgresql')
+            if 'mariadb' in servicelist:
+                servicelist.remove('mariadb')
         process_file="/etc/xcat/console.lock"
         if os.path.exists(process_file):
             with open(process_file,'rt') as handle:

--- a/HA/xcatha.py
+++ b/HA/xcatha.py
@@ -248,6 +248,11 @@ class xcat_ha_utils:
             servicelist.remove('postgresql')
         elif dbtype == 'postgresql' and 'mariadb' in servicelist:
             servicelist.remove('mariadb')
+        elif dbtype == 'sqlite':
+            if 'postgresql' in servicelist:
+                servicelist.remove('postgresql')
+            if 'mariadb' in servicelist:
+                servicelist.remove('mariadb')
         cmd="ps -ef|grep 'conserver\|goconserver'|grep -v grep"
         output=os.popen(cmd).read()
         if output:
@@ -271,9 +276,11 @@ class xcat_ha_utils:
             servicelist.remove('postgresql')
         elif dbtype == 'postgresql' and 'mariadb' in servicelist:
             servicelist.remove('mariadb')
-        elif dbtype == 'sqlite' and 'mariadb' in servicelist and 'postgresql' in servicelist:
-            servicelist.remove('postgresql')
-            servicelist.remove('mariadb')
+        elif dbtype == 'sqlite':
+            if 'mariadb' in servicelist:
+                servicelist.remove('mariadb')
+            if 'postgresql' in servicelist:
+                servicelist.remove('mariadb')
         return_code=0
         for value in reversed(servicelist):
             if self.disable_service(value):
@@ -387,8 +394,7 @@ class xcat_ha_utils:
             if self.check_service_status("xcatd") is not 0:
                 if self.restart_service("xcatd"):  
                     raise HaException(setup_process_msg)   
-                else:
-                    os.environ["PATH"]=xcat_env+os.environ["PATH"]
+            self.source_xcat_profile()
             if dbtype == "postgresql":
                 cmd="pgsqlsetup -i -a "+vip+" -a "+physical_ip
                 cmd_msg="export XCATPGPW=xxxxxx;pgsqlsetup -i -a "+vip+" -a "+physical_ip
@@ -792,7 +798,7 @@ class xcat_ha_utils:
             if os.path.exists(dbfile):
                 res=self.find_line(dbfile, physical_ip)
                 if res is 0:
-                    addline="host    all          all        "+physical_ip+"/32      md5"
+                    addline="host    all          all        "+physical_ip+"/32      md5\n"
                     if dryrun:
                         logger.debug('Added line "%s" to %s configuration file %s [Dryrun]' %(addline, dbtype, dbfile))
                     else:
@@ -802,7 +808,7 @@ class xcat_ha_utils:
                         logger.debug('Added line "%s" to %s configuration file %s' %(addline, dbtype, dbfile))
                 res=self.find_line(dbfile, vip)
                 if res is 0:
-                    addline="host    all          all        "+vip+"/32      md5"
+                    addline="host    all          all        "+vip+"/32      md5\n"
                     if dryrun:
                         logger.debug('Added line "%s" to %s configuration file %s [Dryrun]' %(addline, dbtype, dbfile))
                     else:
@@ -1013,7 +1019,7 @@ def parse_arguments():
     args = parser.parse_args()
     return args
 
-def get_user_input():
+def get_user_input(ignore_dryrun=None):
     retry=5
     return_code=0
     while True :
@@ -1028,13 +1034,72 @@ def get_user_input():
             return_code=1
             break
         else:
-            print "Continue? [[Y]es/[N]o/[D]ryrun]:"
+            if ignore_dryrun:
+                print "Continue? [[Y]es/[N]o]:"
+            else:
+                print "Continue? [[Y]es/[N]o/[D]ryrun]:"
             retry=retry-1
         if retry < 1:
             return_code=1
             break
     return return_code
 
+def get_db_type_from_user():
+    retry=5
+    confirm=""
+    while True :
+        confirm=raw_input()
+        if confirm not in ["postgresql", "mariadb", "sqlite"]:
+            print "Enter DB type [postgresql/mariadb/sqlite]"
+            retry=retry-1
+        else:
+            break
+        if retry < 1:
+            break
+    return confirm
+
+def interactive_activate(obj,virtual_ip):
+    print "[Admin] Enter DB type [postgresql/mariadb/sqlite]:"
+    dbtype=get_db_type_from_user()  
+    print "[Admin] Verify VIP"+virtual_ip+" is configured in node"
+    print "Continue? [[Y]es/[N]o]:"
+    return_code=get_user_input(1)
+    if return_code is 2:
+        return 1
+    print "[Admin] Verify that the following is configured to be saved in shared storage and accessible from this node:"
+    if dbtype == 'mariadb' and '/var/lib/pgsql' in shared_fs:
+        shared_fs.remove('/var/lib/pgsql')
+    if dbtype == 'postgresql' and '/var/lib/mysql' in shared_fs:
+        shared_fs.remove('/var/lib/mysql')
+    for shfs in shared_fs:
+        print "... "+shfs
+    print "Continue? [[Y]es/[N]o]:"
+    return_code=get_user_input(1)
+    if return_code is 2:
+        return 1
+    print "[xCAT] Starting up services:"
+    if dbtype == 'mariadb' and 'postgresql' in service_list:
+        service_list.remove('postgresql')
+    elif dbtype == 'postgresql' and 'mariadb' in service_list:
+        service_list.remove('mariadb')
+    elif dbtype == 'sqlite':
+        if 'mariadb' in service_list:
+            service_list.remove('mariadb')
+        if 'postgresql' in service_list:
+            service_list.remove('postgresql')
+    for service in service_list:
+        print "... "+service
+    print "Continue? [[Y]es/[N]o/[D]ryrun]:"
+    return_code=get_user_input()
+    if return_code is 2:
+        return 1
+    elif return_code is 1:
+        dryrun=1
+    elif return_code is 0:
+        dryrun=0
+    restore_host_name=obj.get_hostname_for_ip(virtual_ip)
+    obj.start_all_services(service_list, dbtype, restore_host_name)
+     
 def main():
     global dryrun
     args=parse_arguments()
@@ -1043,20 +1108,12 @@ def main():
         dryrun = 1
     try:
         if args.activate:
-            if not args.path:
-                logger.error("Option -p is required for xCAT MN activation")
-                return 1
-            if not args.netmask:
-                args.netmask="255.255.255.0"
-            if not args.dbtype:
-                args.dbtype="sqlite"
-            if args.host_name:
-                logger.error("Option -n is not valid for xCAT MN activation")
-                return 1
-
-            logger.info("Activating this node as xCAT primary MN")
-            obj.activate_management_node(args.nic, args.virtual_ip, args.dbtype, args.path, args.netmask)
-
+            if args.nic and args.virtual_ip and args.path:
+                logger.info("Activating this node as xCAT primary MN")
+                obj.activate_management_node(args.nic, args.virtual_ip, args.dbtype, args.path, args.netmask)
+            else:
+                interactive_activate(obj,args.virtual_ip) 
+                
         if args.deactivate:
             dbtype=obj.current_database_type("")
             if args.nic and args.virtual_ip:
@@ -1096,6 +1153,7 @@ def main():
                 elif return_code is 0:
                     dryrun=0
                 obj.disable_all_services(service_list, dbtype)
+                logger.info("This machine is set to standby management node successfully...") 
         if args.setup:
             if not args.netmask:
                 args.netmask="255.255.255.0"

--- a/HA/xcatha.py
+++ b/HA/xcatha.py
@@ -907,14 +907,24 @@ class xcat_ha_utils:
         self.unconfigure_shared_data(shared_fs,dbtype)
         self.unconfigure_vip(vip, nic)
 
+    def clean_vip_hostname(self, vip, nic):
+        """clean up VIP"""
+        restore_host_name=self.get_original_host()
+        restore_host_ip=self.get_original_ip()
+        if restore_host_name and restore_host_ip:
+            self.change_hostname(restore_host_name,restore_host_ip)
+        else:
+            logger.warning("Unable to restore original hostname")
+        self.unconfigure_vip(vip, nic)
+
     def deactivate_management_node(self, nic, vip, dbtype):
         """deactivate management node"""
         global setup_process_msg
         setup_process_msg="########## Deactivate stage ##########"
         logger.info(setup_process_msg)
-        self.clean_env(vip, nic, dbtype)
         self.disable_all_services(service_list, dbtype)
         self.stop_all_services(service_list, dbtype)
+        self.clean_vip_hostname(vip, nic)
         logger.info("This machine is set to standby management node successfully...")
 
     def check_HA_directory(self, path):
@@ -942,7 +952,6 @@ class xcat_ha_utils:
             else:
                 logger.error("Can not find the hostname to set")
             self.check_xcat_exist_in_shared_data(path)
-            self.configure_shared_data(path, shared_fs, dbtype)
             self.start_all_services(service_list, dbtype, restore_host_name)
             logger.info("This machine is set to primary management node successfully...")
         except:
@@ -1085,7 +1094,7 @@ def main():
                 elif return_code is 0:
                     dryrun=0
                 obj.disable_all_services(service_list, dbtype)
-                
+                logger.info("This machine is set to standby management node successfully...") 
         if args.setup:
             if not args.netmask:
                 args.netmask="255.255.255.0"


### PR DESCRIPTION
enhance:
1. Support interactive|activate deactivate process for https://github.com/xcat2/xcat2-task-management/issues/184 and https://github.com/xcat2/xcat2-task-management/issues/185
2. During deactivate process, if user use "python xcatha.py -d -v 10.5.106.22 -i eth0:0", this means he want to remove vip, we can keep the original process. But unlink share data is no need in deactivate process, so I delete it.
3. During non-interactive activate process, we do not need to re-link the share data, so I delete this part.
4. fix https://github.com/xcat2/xcat-extensions/issues/20
5. fix https://github.com/xcat2/xcat-extensions/issues/29

UT
```
[root@bybc0607 ~]# python xcatha.py -d
2018-06-14 04:54:15,960 - INFO - [xCAT] Shutting down services:
... goconserver
... conserver
... ntpd
... dhcpd
... named
... xcatd
... postgresql
Continue? [[Y]es/[N]o/[D]ryrun]:
Y
2018-06-14 04:54:21,809 - DEBUG - systemctl stop goconserver [Passed]
2018-06-14 04:54:21,821 - DEBUG - systemctl stop conserver [Passed]
2018-06-14 04:54:21,837 - DEBUG - systemctl stop ntpd [Passed]
2018-06-14 04:54:21,850 - DEBUG - systemctl stop dhcpd [Passed]
2018-06-14 04:54:21,862 - DEBUG - systemctl stop named [Passed]
2018-06-14 04:54:22,391 - DEBUG - systemctl stop xcatd [Passed]
2018-06-14 04:54:23,419 - DEBUG - systemctl stop postgresql [Passed]
[xCAT] Disabling services from starting on reboot:
... goconserver
... conserver
... ntpd
... dhcpd
... named
... xcatd
... postgresql
Continue? [[Y]es/[N]o/[D]ryrun]:
Y
2018-06-14 04:54:26,627 - DEBUG - systemctl disable goconserver [Passed]
conserver.service is not a native service, redirecting to /sbin/chkconfig.
Executing /sbin/chkconfig conserver off
2018-06-14 04:54:26,689 - DEBUG - systemctl disable conserver [Passed]
2018-06-14 04:54:26,742 - DEBUG - systemctl disable ntpd [Passed]
2018-06-14 04:54:26,794 - DEBUG - systemctl disable dhcpd [Passed]
2018-06-14 04:54:26,847 - DEBUG - systemctl disable named [Passed]
xcatd.service is not a native service, redirecting to /sbin/chkconfig.
Executing /sbin/chkconfig xcatd off
2018-06-14 04:54:26,905 - DEBUG - systemctl disable xcatd [Passed]
2018-06-14 04:54:26,958 - DEBUG - systemctl disable postgresql [Passed]
2018-06-14 04:54:26,958 - INFO - This machine is set to standby management node successfully...
```
```
[root@bybc0607 ~]# python xcatha.py -a -v 10.5.106.70
[Admin] Enter DB type [postgresql/mariadb/sqlite]:
postgrepsql
Enter DB type [postgresql/mariadb/sqlite]
postgresql
[Admin] Verify VIP10.5.106.70 is configured in node
Continue? [[Y]es/[N]o]:
Y
[Admin] Verify that the following is configured to be saved in shared storage and accessible from this node:
... /install
... /etc/xcat
... /root/.xcat
... /var/lib/pgsql
... /tftpboot
Continue? [[Y]es/[N]o]:
Y
[xCAT] Starting up services:
... postgresql
... xcatd
... named
... dhcpd
... ntpd
... conserver
... goconserver
Continue? [[Y]es/[N]o/[D]ryrun]:
Y
2018-06-14 04:56:17,819 - INFO - ===> Start all services stage <===
2018-06-14 04:56:18,955 - DEBUG - systemctl start postgresql [Passed]
2018-06-14 04:56:21,706 - DEBUG - systemctl start xcatd [Passed]
    domain=cluster.com
2018-06-14 04:56:22,077 - DEBUG - lsdef -t site -i domain|grep domain [Passed]
2018-06-14 04:56:22,077 - WARNING - Long hostname is not in "/etc/hosts". "named" service will not be started
Renamed existing dhcp configuration file to  /etc/dhcp/dhcpd.conf.xcatbak

The dhcp server must be restarted for OMAPI function to work
Warning: No dynamic range specified for 10.0.0.0. If hardware discovery is being used, a dynamic range is required.
2018-06-14 04:56:22,545 - DEBUG - makedhcp -n [Passed]
2018-06-14 04:56:22,793 - DEBUG - makedhcp -a [Passed]
2018-06-14 04:56:22,856 - DEBUG - systemctl start ntpd [Passed]
```