### PR TITLE
fix 3 issues for xcatha.py -a

### DIFF
--- a/HA/xcatha.py
+++ b/HA/xcatha.py
@@ -178,8 +178,10 @@ class xcat_ha_utils:
                 for ln in handle:
                     if 'goconserver' in ln:
                         servicelist.remove('conserver')
+                        break
                     else:
                         servicelist.remove('goconserver')
+                        break
         else:
             servicelist.remove('conserver')
             servicelist.remove('goconserver')
@@ -206,6 +208,7 @@ class xcat_ha_utils:
                     else:
                         # Domain in the site table, 
                         domain_in_site=1
+                        host_name=host_name.strip()
                         long_name = self.find_line(etc_hosts, host_name+'.')
                         if long_name is 1:
                             # long hostname in /etc/hosts
@@ -866,7 +869,7 @@ class xcat_ha_utils:
 
     def get_hostname_for_ip(self,ip):
         """get hostname for the passed in ip"""
-        hostname=os.popen("getent hosts "+ip+" | awk -F ' ' '{print $2}' | uniq").read()
+        hostname=os.popen("getent hosts "+ip+" | awk -F ' ' '{print $2}' | awk -F'.' '{print $1}'| uniq").read()
         return hostname
 
     def get_hostname_original_ip(self):


### PR DESCRIPTION
Fix 3 issues:
1.  fix remove one more goconserver
```
2018-06-22 05:12:16,124 - INFO - ===> Start all services stage <===
Traceback (most recent call last):
  File "./xcatha.py", line 1194, in <module>
    main()
  File "./xcatha.py", line 1162, in main
    interactive_activate(obj,args.virtual_ip,args.dbtype)
  File "./xcatha.py", line 1143, in interactive_activate
    obj.start_all_services(service_list, dbtype, restore_host_name)
  File "./xcatha.py", line 182, in start_all_services
    servicelist.remove('goconserver')
ValueError: list.remove(x): x not in list
```
2. "get_hostname_for_ip" should return short name.
3.  remove "\n" from hostname