### PR TITLE
fix missing \n between lines in xcatha.py

### DIFF
--- a/HA/xcatha.py
+++ b/HA/xcatha.py
@@ -789,7 +789,7 @@ class xcat_ha_utils:
             res=self.find_line(etc_ha_mn, ip_and_host)
             if res is 0:
                 hamnfile=open(etc_ha_mn,'a')
-                hamnfile.write(ip_and_host)
+                hamnfile.write(ip_and_host+"\n")
                 hamnfile.close
 
     def modify_db_configure_file(self, dbtype, dbpath, physical_ip, vip):


### PR DESCRIPTION
Here will create /etc/xcat/ha_mn file to record the physical ip and node for HA MN.
This PR is fix missing "\n" between lines during writing /etc/xcat/ha_mn.