### PR TITLE
raid1_rh.sh: Make md RAID creation fail proof (fixes #40)

### DIFF
--- a/partition/raid1_rh.sh
+++ b/partition/raid1_rh.sh
@@ -106,6 +106,10 @@ rm -fr $tmpdir
 disk1=$(tail -n +1 /tmp/xcat_sorted_disks|head -n1 |cut -d'|' -f 2|cut -d' ' -f1)
 disk2=$(tail -n +2 /tmp/xcat_sorted_disks|head -n1 |cut -d'|' -f 2|cut -d' ' -f1)
 
+# erase all existing md RAIDs
+mdadm --stop /dev/md/*
+mdadm --zero-superblock ${disk1}*
+mdadm --zero-superblock ${disk2}*
 
 ########################################################################
 # Part 2: create the partition scheme file /tmp/partitionfile

--- a/partition/raid1_rh.sh
+++ b/partition/raid1_rh.sh
@@ -103,8 +103,8 @@ echo "[$0] the output file is: $output_file"
 rm -fr $tmpdir
 
 
-disk1=$(tail -n +1 /tmp/xcat_sorted_disks|head -n1 |cut -d'|' -f 2|cut -d' ' -f1)
-disk2=$(tail -n +2 /tmp/xcat_sorted_disks|head -n1 |cut -d'|' -f 2|cut -d' ' -f1)
+disk1=$(sed '1q;d' /tmp/xcat_sorted_disks |cut -d'|' -f 2|cut -d' ' -f1)
+disk2=$(sed '2q;d' /tmp/xcat_sorted_disks |cut -d'|' -f 2|cut -d' ' -f1)
 
 # disable md RAID resync during installation
 # this speeds up the installation process significantly

--- a/partition/raid1_rh.sh
+++ b/partition/raid1_rh.sh
@@ -106,6 +106,11 @@ rm -fr $tmpdir
 disk1=$(tail -n +1 /tmp/xcat_sorted_disks|head -n1 |cut -d'|' -f 2|cut -d' ' -f1)
 disk2=$(tail -n +2 /tmp/xcat_sorted_disks|head -n1 |cut -d'|' -f 2|cut -d' ' -f1)
 
+# disable md RAID resync during installation
+# this speeds up the installation process significantly
+echo 0 > /proc/sys/dev/raid/speed_limit_max
+echo 0 > /proc/sys/dev/raid/speed_limit_min
+
 # erase all existing md RAIDs
 mdadm --stop /dev/md/*
 mdadm --zero-superblock ${disk1}*

--- a/partition/raid1_rh.sh
+++ b/partition/raid1_rh.sh
@@ -107,7 +107,8 @@ disk1=$(sed '1q;d' /tmp/xcat_sorted_disks |cut -d'|' -f 2|cut -d' ' -f1)
 disk2=$(sed '2q;d' /tmp/xcat_sorted_disks |cut -d'|' -f 2|cut -d' ' -f1)
 
 # disable md RAID resync during installation
-# this speeds up the installation process significantly
+# this speeds up the ignstallation process significantly
+echo "[$0] disabling md RAID resync during installation"
 echo 0 > /proc/sys/dev/raid/speed_limit_max
 echo 0 > /proc/sys/dev/raid/speed_limit_min
 
@@ -121,9 +122,12 @@ disk2_mds=$(awk '/ '${disk2_sd}'[0-9]+\[/ {sub("md","");print $1}' /proc/mdstat)
 all_mds=$(printf '%s\n%s' "$disk1_mds" "$disk2_mds" | sort -u)
 
 for md in $all_mds; do
+    echo "[$0] stopping md device: /dev/md/${md}"
     mdadm --stop /dev/md/${md}
 done
+echo "[$0] zeroing superblocks of ${disk1}-part*"
 mdadm --zero-superblock ${disk1}-part*
+echo "[$0] zeroing superblocks of ${disk2}-part*"
 mdadm --zero-superblock ${disk2}-part*
 
 ########################################################################


### PR DESCRIPTION
- Make sure previous md RAIDs are deleted c84d0327c4c5d18bb7e1a4cba1c2cca482a0e90b
- Disable md RAID resync during installation a074747deaac847fe424b7a6f63af551d3f068e3

See #40 for more information.